### PR TITLE
as_matrix() tidak berfungsi

### DIFF
--- a/edisi2/7 k-Nearest Neigbors.py
+++ b/edisi2/7 k-Nearest Neigbors.py
@@ -12,7 +12,7 @@ irisDataset["Species"] = pd.factorize(irisDataset.Species)[0]
 irisDataset = irisDataset.drop(labels="Id", axis=1)
 
 #mengubah dataframe ke array numpy
-irisDataset = irisDataset.as_matrix()
+irisDataset = irisDataset.to_numpy()
 
 #membagi dataset, 40 baris data untuk training
 #dan 20 baris data untuk testing


### PR DESCRIPTION
memperbaiki error


Traceback (most recent call last):
  File "7 k-Nearest Neigbors.py", line 15, in <module>
    irisDataset = irisDataset.as_matrix().values
  File "C:\Users\......\AppData\Local\Programs\Python\Python38-32\lib\site-packages\pandas\core\generic.py", line 5139, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'as_matrix'